### PR TITLE
[PR] Add support for HTML snippets across a multisite network

### DIFF
--- a/tests/test-wsu-html-snippets.php
+++ b/tests/test-wsu-html-snippets.php
@@ -68,6 +68,10 @@ class Tests_WSU_HTML_Snippets extends WP_UnitTestCase {
 		$post_id = $this->factory->post->create( array( 'post_content' => '[html_snippet snippet_id="' . $html_snippet_id . '"]' ) );
 		$post = get_post( $post_id );
 
-		$this->assertContains( '<h1>A Headline</h1>', apply_filters( 'the_content', $post->post_content ) );
+		if ( is_multisite() ) {
+			$this->assertContains( '<h1>A Headline</h1>', apply_filters( 'the_content', $post->post_content ) );
+		} else {
+			$this->assertEquals( "\n", apply_filters( 'the_content', $post->post_content ) );
+		}
 	}
 }

--- a/tests/test-wsu-html-snippets.php
+++ b/tests/test-wsu-html-snippets.php
@@ -55,4 +55,19 @@ class Tests_WSU_HTML_Snippets extends WP_UnitTestCase {
 
 		$this->assertContains( '<div id="container-id"><h1>A Headline</h1>' . "\n" . '</div>', apply_filters( 'the_content', $post->post_content ) );
 	}
+
+	/**
+	 * An HTML snippet embedded from another site will need a snippet ID built from the site ID and the ID of the HTML
+	 * snippet itself.
+	 */
+	public function test_html_snippet_shortcode_with_snippet_id() {
+		$html_snippet_id = $this->factory->post->create( array( 'post_type' => 'wsu_html_snippet', 'post_content' => '<h1>A Headline</h1>' ) );
+		$site_id = get_current_blog_id();
+
+		$html_snippet_id = $site_id . '-' . $html_snippet_id;
+		$post_id = $this->factory->post->create( array( 'post_content' => '[html_snippet snippet_id="' . $html_snippet_id . '"]' ) );
+		$post = get_post( $post_id );
+
+		$this->assertContains( '<h1>A Headline</h1>', apply_filters( 'the_content', $post->post_content ) );
+	}
 }

--- a/wsuwp-html-snippets.php
+++ b/wsuwp-html-snippets.php
@@ -6,8 +6,6 @@ Description: Embed common HTML content throughout a WordPress site.
 Author: washingtonstateuniversity, jeremyfelt
 Author URI: https://web.wsu.edu/
 Plugin URI: https://web.wsu.edu/
-Text Domain: wsuwp-html-snippets
-Domain Path: /languages
 */
 
 class WSU_HTML_Snippets {

--- a/wsuwp-html-snippets.php
+++ b/wsuwp-html-snippets.php
@@ -74,13 +74,10 @@ class WSU_HTML_Snippets {
 		);
 		$atts = wp_parse_args( $atts, $default_atts );
 
-		if ( ( empty( $atts['id'] ) || 0 === absint( $atts['id'] ) ) && empty( $atts['snippet_id'] ) ) {
-			return '';
-		}
-
 		// If a snippet ID has been passed, we default to parsing it. This should be a
 		// string that breaks into a site ID and a post ID for the desired HTML snippet.
-		if ( ! empty( $atts['snippet_id'] ) ) {
+		// This is only supported in multisite.
+		if ( is_multisite() && ! empty( $atts['snippet_id'] ) ) {
 			$snippet_id = explode( '-', $atts['snippet_id'] );
 
 			if ( 2 !== count( $snippet_id ) ) {
@@ -93,9 +90,13 @@ class WSU_HTML_Snippets {
 			switch_to_blog( $site_id );
 		}
 
+		if ( ( empty( $atts['id'] ) || 0 === absint( $atts['id'] ) ) ) {
+			return '';
+		}
+
 		$post = get_post( $atts['id'] );
 
-		if ( ms_is_switched() ) {
+		if ( is_multisite() && ms_is_switched() ) {
 			restore_current_blog();
 		}
 

--- a/wsuwp-html-snippets.php
+++ b/wsuwp-html-snippets.php
@@ -67,17 +67,37 @@ class WSU_HTML_Snippets {
 	public function display_html_snippet( $atts ) {
 		$default_atts = array(
 			'id' => 0,
+			'snippet_id' => '',
 			'container' => '',
 			'container_class' => '',
 			'container_id' => '',
 		);
 		$atts = wp_parse_args( $atts, $default_atts );
 
-		if ( empty( $atts['id'] ) || 0 === absint( $atts['id'] ) ) {
+		if ( ( empty( $atts['id'] ) || 0 === absint( $atts['id'] ) ) && empty( $atts['snippet_id'] ) ) {
 			return '';
 		}
 
+		// If a snippet ID has been passed, we default to parsing it. This should be a
+		// string that breaks into a site ID and a post ID for the desired HTML snippet.
+		if ( ! empty( $atts['snippet_id'] ) ) {
+			$snippet_id = explode( '-', $atts['snippet_id'] );
+
+			if ( 2 !== count( $snippet_id ) ) {
+				return '';
+			}
+
+			$site_id = absint( $snippet_id[0] );
+			$atts['id'] = absint( $snippet_id[1] );
+
+			switch_to_blog( $site_id );
+		}
+
 		$post = get_post( $atts['id'] );
+
+		if ( ms_is_switched() ) {
+			restore_current_blog();
+		}
 
 		if ( ! $post || $this::$content_type_slug !== $post->post_type ) {
 			return '';
@@ -121,6 +141,12 @@ class WSU_HTML_Snippets {
 					'type'     => 'post_select',
 					'query'    => array( 'post_type' => $this::$content_type_slug ),
 					'multiple' => false,
+				),
+
+				array(
+					'label'    => 'Or HTML Snippet ID',
+					'attr'     => 'snippet_id',
+					'type'     => 'text',
 				),
 
 				array(

--- a/wsuwp-html-snippets.php
+++ b/wsuwp-html-snippets.php
@@ -19,6 +19,7 @@ class WSU_HTML_Snippets {
 	 */
 	public function __construct() {
 		add_action( 'init', array( $this, 'register_content_type' ) );
+		add_action( 'add_meta_boxes', array( $this, 'add_meta_boxes' ), 10 );
 		add_action( 'init', array( $this, 'setup_shortcode_ui' ) );
 		add_shortcode( 'html_snippet', array( $this, 'display_html_snippet' ) );
 	}
@@ -55,6 +56,32 @@ class WSU_HTML_Snippets {
 			'supports'           => array( 'title', 'editor' ),
 		);
 		register_post_type( $this::$content_type_slug, $args );
+	}
+
+	/**
+	 * Add the meta boxes used for HTML Snippets.
+	 *
+	 * @param string $post_type The post type of the current post being edited.
+	 */
+	public function add_meta_boxes( $post_type ) {
+		if ( $this::$content_type_slug !== $post_type || ! is_multisite() ) {
+			return;
+		}
+
+		add_meta_box( 'wsu_snippet_id', 'Snippet ID', array( $this, 'display_snippet_id_metabox' ), null, 'side', 'high' );
+	}
+
+	/**
+	 * Display the snippet ID for the current HTML snippet being edited. This snippet ID can
+	 * be used to embed a snippet in content throughout this site's network.
+	 *
+	 * @param WP_Post $post The current post being edited.
+	 */
+	public function display_snippet_id_metabox( $post ) {
+		?>
+		<p class="description">Use this ID to embed an HTML snippet in another site on this network.</p>
+		<p><strong><?php echo get_current_blog_id() . '-' . $post->ID; ?></strong></p>
+		<?php
 	}
 
 	/**

--- a/wsuwp-html-snippets.php
+++ b/wsuwp-html-snippets.php
@@ -112,6 +112,13 @@ class WSU_HTML_Snippets {
 			}
 
 			$site_id = absint( $snippet_id[0] );
+			$site_details = get_blog_details( $site_id );
+
+			// The snippet must be pulled from a site on the same network.
+			if ( get_current_site()->id != $site_details->site_id ) {
+				return '';
+			}
+
 			$atts['id'] = absint( $snippet_id[1] );
 
 			switch_to_blog( $site_id );


### PR DESCRIPTION
Provides support for a `snippet_id` attribute, which is a combination of site ID and HTML snippet post ID (e.g `2-45`).

When a site ID matches a site on the existing network, the HTML snippet with the associated post ID will be pulled from that site and embedded in the content of the post on the current site.

Improvements should be targeted in the future toward aligning the user interface, as parts of this process are a cheap hack. :)
