### PR TITLE
[PR] Apply wpautop to snippet content in the shortcode if necessary

### DIFF
--- a/wsuwp-html-snippets.php
+++ b/wsuwp-html-snippets.php
@@ -151,10 +151,16 @@ class WSU_HTML_Snippets {
 
 			$container_open .= '>';
 
-			return $container_open .  apply_filters( 'the_content', $post->post_content ) . '</' . $atts['container'] . '>';
+			$content = $container_open .  apply_filters( 'the_content', $post->post_content ) . '</' . $atts['container'] . '>';
+		} else {
+			$content = apply_filters( 'the_content', $post->post_content );
 		}
 
-		return apply_filters( 'the_content', $post->post_content );
+		if ( ! has_filter( 'the_content', 'wpautop' ) ) {
+			$content = wpautop( $content );
+		}
+
+		return $content;
 	}
 
 	/**


### PR DESCRIPTION
Our parent theme removes `wpautop` from `the_content` so that it
can build individual sections of content rather than applying it
the the built content as a whole. Because of this, we can detect
if the filter is not on and apply the function ourselves.
