### PR TITLE
[PR] Process shortcodes inside the shortcode before used as a shortcode

### DIFF
--- a/wsuwp-html-snippets.php
+++ b/wsuwp-html-snippets.php
@@ -152,9 +152,12 @@ class WSU_HTML_Snippets {
 			$container_open .= '>';
 
 			$content = $container_open .  apply_filters( 'the_content', $post->post_content ) . '</' . $atts['container'] . '>';
+			$content = do_shortcode( $content );
 		} else {
 			$content = apply_filters( 'the_content', $post->post_content );
+			$content = do_shortcode( $content );
 		}
+
 
 		if ( ! has_filter( 'the_content', 'wpautop' ) ) {
 			$content = wpautop( $content );


### PR DESCRIPTION
If a shortcode was inside an HTML snippet, and was not processed
until after the snippet was built as part of the content in the
post embedding the snippet, then the HTML would be stripped for
users without unfiltered HTML capabilities.
